### PR TITLE
mtmd: use common log.h in mtmd-helper.cpp

### DIFF
--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -32,8 +32,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 
-#define LOG_INF(...) fprintf(stdout, __VA_ARGS__)
-#define LOG_ERR(...) fprintf(stderr, __VA_ARGS__)
+#include "log.h"
 
 size_t mtmd_helper_get_n_tokens(const mtmd_input_chunks * chunks) {
     size_t n_tokens = 0;


### PR DESCRIPTION
Replace local LOG_* macros in tools/mtmd/mtmd-helper.cpp with common log.h. This allows disabling INFO logs via common logging verbosity instead of hardwired fprintf.\n\n- remove local LOG_INF/LOG_ERR defines\n- include common/log.h\n- no functional change besides logging control