### PR TITLE
mtmd: route logging to common/log.h and link common (base 9515c6131)

### DIFF
--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(mtmd
             mtmd-helper.h
             )
 
-target_link_libraries     (mtmd PUBLIC ggml llama)
+target_link_libraries     (mtmd PUBLIC ggml llama common)
 target_link_libraries     (mtmd PRIVATE Threads::Threads)
 target_include_directories(mtmd PUBLIC  .)
 target_include_directories(mtmd PRIVATE ../..)

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -10,6 +10,7 @@
 #include "mtmd.h"
 #include "mtmd-helper.h"
 #include "llama.h"
+#include "log.h"
 
 #include <algorithm>
 #include <cinttypes>
@@ -32,8 +33,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 
-#define LOG_INF(...) fprintf(stdout, __VA_ARGS__)
-#define LOG_ERR(...) fprintf(stderr, __VA_ARGS__)
+
 
 size_t mtmd_helper_get_n_tokens(const mtmd_input_chunks * chunks) {
     size_t n_tokens = 0;


### PR DESCRIPTION
- Replace local LOG_INF/LOG_ERR with common/log.h\n- Link mtmd PUBLIC against common to propagate includes\n- Base: 9515c6131aecaccc955fdedcfe16c3e030aaefcb\n\nVerified on Windows/MSVC with mtmd enabled. Produces mtmd.lib and llama-mtmd-cli.exe.